### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-publish-drunk.yml
+++ b/.github/workflows/build-publish-drunk.yml
@@ -13,6 +13,8 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/baoduy/drunk-pulumi-azure/security/code-scanning/3](https://github.com/baoduy/drunk-pulumi-azure/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block to the workflow. The best approach is to set the default permissions at the workflow level to the minimum required (usually `contents: read`), and then override the permissions at the job or step level where more privileges are needed. In this workflow, the `build` job needs `contents: write` to create a release using `actions/create-release@v1`. Therefore, add a `permissions` block at the job level for `build` with `contents: write`. If you want to be even more restrictive, you could specify only the permissions required for the release step (e.g., `contents: write`), but for simplicity and clarity, setting `contents: write` for the job is sufficient.

**What to change:**  
- Add a `permissions:` block under the `build:` job, before `runs-on: ubuntu-latest`, with `contents: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
