### PR TITLE
Potential fix for code scanning alert no. 2: Regular expression injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "@pulumi/tls": "^5.2.1",
     "netmask": "^2.0.2",
     "node-forge": "^1.3.1",
-    "to-words": "^4.7.0"
+    "to-words": "^4.7.0",
+    "lodash": "^4.17.21"
   },
   "prettier": {
     "singleQuote": true

--- a/src/KeyVault/Helper.ts
+++ b/src/KeyVault/Helper.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { Output, output } from '@pulumi/pulumi';
 import { KeyVaultInfo, NamedWithVaultType, WithVaultInfo } from '../types';
 import getKeyVaultBase from '@drunk-pulumi/azure-providers/AzBase/KeyVaultBase';
@@ -13,7 +14,7 @@ export const getVaultItemName = (
   currentStack: string = stack
 ) => {
   name = name
-    .replace(new RegExp(currentStack, 'g'), '') // Replace occurrences of "stack" variable with "-"
+    .replace(new RegExp(_.escapeRegExp(currentStack), 'g'), '') // Replace occurrences of "stack" variable with "-"
     .replace(/\.|_|\s/g, '-') // Replace ".", "_", and spaces with "-"
     .replace(/-+/g, '-') // Replace multiple dashes with a single dash
     .toLowerCase(); // Convert the result to lowercase


### PR DESCRIPTION
Potential fix for [https://github.com/baoduy/drunk-pulumi-azure/security/code-scanning/2](https://github.com/baoduy/drunk-pulumi-azure/security/code-scanning/2)

To fix the problem, we need to sanitize `currentStack` before using it to construct a regular expression. The best way to do this is to escape all regex meta-characters in `currentStack` so that it is treated as a literal string in the regular expression. The recommended approach is to use a well-known library such as Lodash's `_.escapeRegExp` function, which safely escapes all regex meta-characters. This requires importing Lodash in `src/KeyVault/Helper.ts` and applying `_.escapeRegExp` to `currentStack` before passing it to the `RegExp` constructor. Only the code in `src/KeyVault/Helper.ts` needs to be changed, specifically the `getVaultItemName` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
